### PR TITLE
browser/feature(voting): methods for vote up/down on questions/answers

### DIFF
--- a/browser/src/app/states/qnaDoc.html
+++ b/browser/src/app/states/qnaDoc.html
@@ -18,7 +18,7 @@
       <div
         ng-if="canVoteQuestion()"
         class="ss-up ss-up-enabled"
-        ng-click="vote(1)"
+        ng-click="voteUp($event)"
       ></div>
       <div
         ng-if="!canVoteQuestion()"
@@ -28,7 +28,7 @@
       <div
         ng-if="canVoteQuestion()"
         class="ss-down ss-down-enabled"
-        ng-click="vote(1)"
+        ng-click="voteDown($event)"
       ></div>
       <div
         ng-if="!canVoteQuestion()"
@@ -62,7 +62,7 @@
           <div
             ng-if="canVoteAnswer(answer)"
             class="ss-up ss-up-enabled"
-            ng-click="vote(1)"
+            ng-click="voteUp($event)"
           ></div>
           <div
             ng-if="!canVoteAnswer(answer)"
@@ -72,7 +72,7 @@
           <div
             ng-if="canVoteAnswer(answer)"
             class="ss-down ss-down-enabled"
-            ng-click="vote(1)"
+            ng-click="voteDown($event)"
           ></div>
           <div
             ng-if="!canVoteAnswer(answer)"

--- a/browser/src/app/states/qnaDoc.js
+++ b/browser/src/app/states/qnaDoc.js
@@ -66,6 +66,28 @@ define(['app/module'], function (module) {
         appRouting.go('^.explore', { q: $scope.searchbarText });
       };
 
+      $scope.voteUp = function (ev) {
+        if (angular.element(ev.target).parent().parent()
+            .hasClass('ss-question')) {
+          $scope.doc.itemTally++;
+        }
+        else {
+          this.answer.itemTally++;
+        }
+        // $scope.doc.update() // @todo Update qna doc in db
+      };
+
+      $scope.voteDown = function (ev) {
+        if (angular.element(ev.target).parent().parent()
+            .hasClass('ss-question')) {
+          $scope.doc.itemTally--;
+        }
+        else {
+          this.answer.itemTally--;
+        }
+        // $scope.doc.update() // @todo Update qna doc in db
+      };
+
       $scope.setPageTitle('doc');
       $scope.searchbarText = appRouting.params.q ? appRouting.params.q : null;
       if ($scope.initializing) {


### PR DESCRIPTION
Putting voteUp/voteDown methods in the ssQnaDoc object wasn't working for me because there was no access to the $scope for that view from there. So they are in the qnaDoc view controller.

Vote methods need to determine if caller is a question or answer. We can get this via a class check via jqLite, which is a bit chained but I think it's fine. Other options are separate methods for questions and answers or adding distinguishing classes to clicked elements.

Currently, the canVote methods are not working. These are based on parseVote(), which I find hard to understand, could use some comments.
