### PR TITLE
fix(browser/explore): on browser refresh, recognize any q param in URL a...

### DIFF
--- a/browser/src/app/states/explore.js
+++ b/browser/src/app/states/explore.js
@@ -13,12 +13,14 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
 
     '$scope',
     '$timeout',
+    '$location',
     'appRouting',
     'ssSearch',
     'allTagsDialog',
     function (
       $scope,
       $timeout,
+      $location,
       appRouting,
       ssSearch,
       allTagsDialog
@@ -86,7 +88,12 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
               $scope.search.criteria.constraints.resolved.value === true;
         }
 
-        $scope.searchbarText = $scope.search.criteria.q;
+        // If q text is in URL, get it and add to search bar
+        var qMatch = location.search.match( /[?&]q=([^&]*)?/ );
+        if (qMatch && qMatch[1]) {
+          var qParam = qMatch[1].replace(/-/g, ' ').replace(/%2D/g, '-');
+          $scope.searchbarText = decodeURIComponent(qParam);
+        }
       };
 
 

--- a/browser/src/app/states/explore.js
+++ b/browser/src/app/states/explore.js
@@ -88,12 +88,7 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
               $scope.search.criteria.constraints.resolved.value === true;
         }
 
-        // If q text is in URL, get it and add to search bar
-        var qMatch = location.search.match( /[?&]q=([^&]*)?/ );
-        if (qMatch && qMatch[1]) {
-          var qParam = qMatch[1].replace(/-/g, ' ').replace(/%2D/g, '-');
-          $scope.searchbarText = decodeURIComponent(qParam);
-        }
+        $scope.searchbarText = $scope.search.criteria.q;
       };
 
 

--- a/browser/src/app/states/explore.js
+++ b/browser/src/app/states/explore.js
@@ -34,7 +34,6 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
         $scope.setLoading(true);
 
         $scope.search = ssSearch.create();
-        applySearchToScope();
 
         setWatches();
       };
@@ -65,7 +64,7 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
         );
       };
 
-      var applyScopeToSearch = function () {
+      $scope.applyScopeToSearch = function () {
         $scope.search.criteria.constraints.userName.value =
             $scope.showMineOnly === true ? $scope.store.session.userName.value :
             null;
@@ -74,7 +73,7 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
         $scope.search.criteria.q = $scope.searchbarText;
       };
 
-      var applySearchToScope = function () {
+      $scope.applySearchToScope = function () {
         // showMineOnly only if the user is a contributor AND they have
         // specified it in the url. see also setShowMineOnly and
         // showMineOnlyEnabled
@@ -100,7 +99,7 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
       // whenever criteria changes, go to the state that represents the
       // criteria's results
       $scope.$on('criteriaChange', function () {
-        applyScopeToSearch();
+        $scope.applyScopeToSearch();
         var newStateParams = $scope.search.getStateParams();
         if (newStateParams.q) {
           newStateParams.q = dasherize(newStateParams.q);
@@ -129,7 +128,7 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
       $scope.runSearch = function () {
         $scope.searching = true;
 
-        applyScopeToSearch();
+        $scope.applyScopeToSearch();
 
         $scope.search.shadowSearch().then(
           function () {

--- a/browser/src/app/states/exploreResults.js
+++ b/browser/src/app/states/exploreResults.js
@@ -31,6 +31,7 @@ define(['app/module','mocks/index'], function (module,mocksIndex) {
       var params = angular.copy(appRouting.params);
       params.q = dedasherize(params.q);
       $scope.search.assignStateParams(params);
+      $scope.applySearchToScope();
       $scope.runSearch();
     }
   ]);


### PR DESCRIPTION
On browser refresh, recognize any q param in URL and put value in search bar. 

This fixes the following issue:
1. Refresh the browser when the URL has a q param (a search-box term): 
http://localhost:3000/?q=java&sort=relevance
2. Param is not recognized and search results display without q param as a search term
