### PR TITLE
fix outgoing links for SO questions and users

### DIFF
--- a/browser/src/app/directives/ssQnaDocMetadata.js
+++ b/browser/src/app/directives/ssQnaDocMetadata.js
@@ -62,8 +62,9 @@ define(['app/module'], function (module) {
               };
               // Return link to Stackoverflow user page
               scope.soUserLink = function () {
-                return scope.soOwnerId() && scope.doc.owner.id ?
-                    'http://stackoverflow.com/users/' + scope.doc.owner.id :
+                return scope.soOwnerId() && scope.doc.owner.originalId ?
+                    'http://stackoverflow.com/users/' +
+                    scope.doc.owner.originalId :
                     null;
               };
               // Is document user valid?

--- a/browser/src/app/states/qnaDoc.html
+++ b/browser/src/app/states/qnaDoc.html
@@ -7,7 +7,7 @@
   <header class="ss-question-title">
     <h3>Q: {{ doc.title }}</h3>
     <div class="ss-so-link">
-      <a href="http://stackoverflow.com{{doc.id}}" target="_blank">
+      <a href="http://stackoverflow.com/questions/{{doc.originalId}}" target="_blank">
         [stackoverflow link]
       </a>
     </div>


### PR DESCRIPTION
This commit fixes the outgoing links for StackOverflow questions and users. The doc.owner.originalId property is forthcoming from the middle tier per @grechaw
