### PR TITLE
browser: make ask state functional

### DIFF
--- a/browser/bower.json
+++ b/browser/bower.json
@@ -29,7 +29,8 @@
     "angular": "1.3.1",
     "angular-cookies": "1.3.1",
     "angular-sanitize": "1.3.1",
-    "angular-mocks": "1.3.1"
+    "angular-mocks": "1.3.1",
+    "ng-tags-input": "2.1.x"
   },
   "devDependencies": {
     "mocha": "1.20.1",
@@ -80,6 +81,14 @@
       "main": [
         "highlight.pack.js",
         "styles/github.css"
+      ]
+    },
+    "ng-tags-input": {
+      "main": [
+        "ng-tags-input.js",
+        "ng-tags-input.css",
+        "ng-tags-input.min.js",
+        "ng-tags-input.min.css"
       ]
     }
   },

--- a/browser/src/app/deps.js
+++ b/browser/src/app/deps.js
@@ -18,11 +18,12 @@ require.config({
     'marked': 'deps/marked/lib/marked<%=options.min%>',
     'angular-marked': 'deps/angular-marked/angular-marked<%=options.min%>',
     'jquery': 'deps/jquery/dist/jquery<%=options.min%>',
-    'highcharts': 'deps/highcharts/highcharts',
+    'highcharts': 'deps/highcharts/highcharts<%=options.min%>',
     'highcharts-ng': 'deps/highcharts-ng/dist/highcharts-ng<%=options.min%>',
     'highlightjs': 'deps/highlightjs/highlight.pack<%=options.min%>',
-    'json': 'deps/requirejs-plugins/src/json',
-    'text': 'deps/requirejs-plugins/lib/text'
+    'json': 'deps/requirejs-plugins/src/json<%=options.min%>',
+    'text': 'deps/requirejs-plugins/lib/text<%=options.min%>',
+    'ng-tags-input': 'deps/ng-tags-input/ng-tags-input<%=options.min%>'
     /* jshint ignore: end */
   },
 
@@ -37,7 +38,8 @@ require.config({
     'angular-sanitize': { deps: ['angular'] },
     'ng-markdown': { deps: ['angular', 'angular-sanitize'] },
     'angular-marked': { deps: ['angular'] },
-    'highlightjs': { exports: 'hljs' }
+    'highlightjs': { exports: 'hljs' },
+    'ng-tags-input': { deps: ['angular'] }
   }
 });
 
@@ -58,6 +60,7 @@ define(
     'angular-marked',
     'angular-sanitize',
     'ng-markdown',
+    'ng-tags-input',
 
     '_marklogic/marklogic'
   ],
@@ -83,6 +86,7 @@ define(
       'hc.marked',
       'ngSanitize',
       'wiz.markdown',
+      'ngTagsInput',
 
       '_marklogic'
     ];

--- a/browser/src/app/states/ask.html
+++ b/browser/src/app/states/ask.html
@@ -1,17 +1,30 @@
-<!-- @todo move Bootstrap form classes (.form-inline, .form-control etc.) into sass without losing styles -->
+<!-- @todo move Bootstrap form classes (.form-inline, .form-control etc.)
+into sass without losing styles -->
 <section class="ss-ask">
   <header>
     <h2>Ask a Question</h2>
   </header>
-  <form class="form-inline ss-ui-incomplete">
+  <p
+    class="has-error"
+    ng-if="error"
+  >
+    {{localError}}
+  </p>
+  <form class="form-inline">
     <div class="ss-ask-title">
-      <label>Title</label> <input type="text" class="form-control" />
+      <label>Title</label>
+      <input type="text" ng-model="qnaDoc.title" class="form-control" />
     </div>
-    <div ss-markdown-editor content="question"></div>
-    <!-- todo https://github.com/TimSchlechter/bootstrap-tagsinput -->
-    <div class="ss-ask-tags ss-ui-incomplete">
-      <label>Tags</label> <input disabled type="text" data-role="tagsinput" class="form-control" />
+    <div ss-markdown-editor content="qnaDoc.text"></div>
+    <div class="ss-ask-tags ss-incomplete">
+      <label>Tags</label>
+      <tags-input ng-model="tagsInput"></tags-input> (tags input in progress)
     </div>
-    <button disabled class="ss-ui-incomplete" ng-click="post()">Post Your Question</button>
+    <button
+      ng-disabled="qnaDoc.$ml.invalid"
+      ng-click="save()"
+    >
+      Post Your Question
+    </button>
   </form>
 </section>

--- a/browser/src/app/states/ask.js
+++ b/browser/src/app/states/ask.js
@@ -2,13 +2,42 @@ define(['app/module'], function (module) {
 
   module.controller('askCtlr', [
 
-    '$scope', 'appRouting',
-    function ($scope, appRouting) {
+    '$scope', 'appRouting', 'ssQnaDoc',
+    function ($scope, appRouting, ssQnaDoc) {
 
       $scope.setPageTitle('ask');
 
-      $scope.post = function () {
-        appRouting.go('qnaDoc');
+      ssQnaDoc.create().attachScope($scope, 'qnaDoc');
+
+      $scope.tagsInput; // store tags-input data
+
+      $scope.save = function () {
+
+        // convert tags-input data from array of objects to array of strings
+        $scope.qnaDoc.tags = $scope.tagsInput.map(function (obj) {
+          return obj.text;
+        });
+
+        // Remove empty answer and comments (used for UI forms on QnaDoc page)
+        delete $scope.qnaDoc.answers;
+        delete $scope.qnaDoc.comments;
+
+        if ($scope.qnaDoc.$ml.valid) {
+          $scope.qnaDoc.post().$ml.waiting.then(function () {
+            appRouting.go('^.qnaDoc', {id: $scope.qnaDoc.id});
+          },
+          function (error) {
+            if (error.status === 401) {
+              $scope.setLocalError(
+                'User does not have permission to ask questions'
+              );
+            }
+            else {
+              throw new Error('Error occurred: ' + JSON.stringify(error));
+            }
+          });
+        }
+
       };
 
     }

--- a/browser/src/app/styles/directives/_ss-markdown-editor.scss
+++ b/browser/src/app/styles/directives/_ss-markdown-editor.scss
@@ -14,6 +14,6 @@
 .markdown-editor, .ss-markdown-editor-preview {
   border: 1px solid #ddd;
   padding: 10px;
-  margin-top: -3px;
+  margin-top: 8px;
   min-height: 100px;
 }

--- a/browser/src/app/styles/states/_ask.scss
+++ b/browser/src/app/styles/states/_ask.scss
@@ -17,10 +17,11 @@
     > *:last-child {
       margin-bottom: 0;
     }
-    input {
+    .ss-ask-title input {
       width: 500px;
     }
     .ss-markdown-editor {
+      padding-top: 10px;
       li {
         cursor: pointer;
       }
@@ -36,19 +37,19 @@
         }
       }
       textarea {
-        height:174px;
+        height: 174px;
+        width: 780px;
+        resize: vertical;
       }
       .divider {
         margin:0 6px;
         color:#D3D3D3;
       }
-      .tab-content {
-        height: 250px;
-        padding:10px 16px;
-        border:1px solid #ddd;
-        border-top:0;
-        border-radius: 0 0 4px 4px;
-      }
+    }
+    tags-input {
+      display: inline-block;
+      width: 600px;
+      vertical-align: middle;
     }
   }
 }

--- a/browser/src/index.html
+++ b/browser/src/index.html
@@ -14,16 +14,17 @@
 
   <title ng-bind="pageTitle + ' - samplestack'">samplestack</title>
 
-  <link rel="stylesheet" type="text/css" href="/app/styles/style.css">
-  <link rel="stylesheet" type="text/css" href="/deps/highlightjs/styles/github.css">
+  <link rel="stylesheet" type="text/css" href="/app/styles/style<%=options.min%>.css">
+  <link rel="stylesheet" type="text/css" href="/deps/highlightjs/styles/github<%=options.min%>.css">
+  <link rel="stylesheet" type="text/css" href="/deps/ng-tags-input/ng-tags-input<%=options.min%>.css">
 
   <!--
   An honest effort to maintain consistency across less-than modern
   browsers.  (In the not too distant future this will be an es6 shim.)
   <script src="/deps/angular/angular<%=options.min%>.js"></script>
   -->
-  <script src="/deps/modernizr/modernizr.js"></script>
-  <script src="/deps/es5-shim/es5-shim.js"></script>
+  <script src="/deps/modernizr/modernizr<%=options.min%>.js"></script>
+  <script src="/deps/es5-shim/es5-shim<%=options.min%>.js"></script>
 
   <!--
   Downloading and running the rest of the app is delayed in order to


### PR DESCRIPTION
Users can now submit a new QnaDoc via the "Ask a Question" view.
After submission, the new QnaDoc is viewable in its ownQnaDoc page and searchable via the search box.
A ng-tags-input directive is integrated and usable, but there is no tag restriction in place yet (the input has the yellow "incomplete" highlighting).
Prior to QnaDoc submission, the empty ssAnswer and ssComment objects (which are on a new QnaDoc by default and are bound to the answer and comment forms in the UI) are remove prior to posting since they are not needed on a new QnaDoc. There can be issues in the middle tier when those empty objects are present.
