### PR TITLE
browser: undef tags bug fix, search bar is ss-incomplete on qnadoc page

### DIFF
--- a/browser/src/_marklogic/domain/mlSearch.js
+++ b/browser/src/_marklogic/domain/mlSearch.js
@@ -366,6 +366,12 @@ define(['_marklogic/module'], function (module) {
         this.results = data;
         var facets = this.results.facets;
         angular.forEach(facets, function (facet, facetName) {
+          if (!facet || !facet.facetValues) {
+            // server may not return a facet object with facetValues
+            facet = {
+              facetValues: []
+            };
+          }
           var facetSpec = self.facets && self.facets[facetName];
           if (facetSpec && facetSpec.valuesType === 'object') {
             var keyed = {};

--- a/browser/src/app/states/qnaDoc.html
+++ b/browser/src/app/states/qnaDoc.html
@@ -1,4 +1,4 @@
-<section class="ss-search-bar">
+<section class="ss-search-bar ss-incomplete">
   <ss-search-bar></ss-search-bar>
 </section>
 


### PR DESCRIPTION
Fix for bug #178
For now, mark search bar container on QnaDoc page as incomplete since it does not work there, can revert when we fix bug
