### PR TITLE
browser: fix "NOT" item in search tips

### DIFF
--- a/browser/src/app/directives/ssSearchBar.html
+++ b/browser/src/app/directives/ssSearchBar.html
@@ -28,6 +28,6 @@
     <dt>status<br />(of question)</dt>
       <dd>answers LE 2 [2 or fewer answers]</dd>
     <dt>operators</dt>
-      <dd>AND [implicit for adjacent terms]<br />OR<br />NOT<br />( ) [grouping]</dd>
+      <dd>AND [implicit for adjacent terms]<br />OR<br />- [negation]<br />( ) [grouping]</dd>
   </dl>
 </div>


### PR DESCRIPTION
See https://github.com/marklogic/samplestack-internal/issues/121
