### PR TITLE
browser: search tips edits

### DIFF
--- a/browser/src/app/directives/ssSearchBar.html
+++ b/browser/src/app/directives/ssSearchBar.html
@@ -20,14 +20,14 @@
   </dl>
   <dl>
     <dt>user name</dt>
-      <dd>user:joeUser [for any submission]<br />askedBy:joeUser<br />answeredBy:joeUser<br />commentedBy:joeUser</dd>
+      <dd>user:joeUser&nbsp;&nbsp;&nbsp;[for any submission]<br />askedBy:joeUser<br />answeredBy:joeUser<br />commentedBy:joeUser</dd>
     <dt>votes</dt>
-      <dd>votes:0<br />votes GT 100 [more than 100 votes]</dd>
+      <dd>votes:0<br />votes GT 100&nbsp;&nbsp;&nbsp;[more than 100 votes]</dd>
   </dl>
   <dl>
-    <dt>status<br />(of question)</dt>
-      <dd>answers LE 2 [2 or fewer answers]</dd>
+    <dt>question status</dt>
+      <dd>answers LE 2&nbsp;&nbsp;&nbsp;[2 or fewer answers]</dd>
     <dt>operators</dt>
-      <dd>AND [implicit for adjacent terms]<br />OR<br />- [negation]<br />( ) [grouping]</dd>
+      <dd>query1 AND query2&nbsp;&nbsp;&nbsp;[implicit for adjacent terms]<br />query1 OR query2<br />-query&nbsp;&nbsp;&nbsp;[negation]<br />(query1 OR query2) AND query3&nbsp;&nbsp;&nbsp;[grouping]</dd>
   </dl>
 </div>

--- a/browser/src/app/styles/directives/_ss-search-bar.scss
+++ b/browser/src/app/styles/directives/_ss-search-bar.scss
@@ -49,21 +49,26 @@
 
 .ss-search-tips-panel {
   width: 100%;
-  height: 150px;
+  height: 142px;
   background-color: #f9f9f9;
   padding: 10px;
 
   dl, dt, dd {
     position: relative;
     float: left;
+    font-size: 0.98em;
   }
 
   dl {
-    width: 33%;
+    width: 32%;
+  }
+
+  dl:last-of-type {
+    width: 36%;
   }
 
   dt {
-    width: 30%;
+    width: 27%;
     margin-bottom: 6px;
     color: #999;
     font-weight: normal;
@@ -71,7 +76,7 @@
   }
 
   dd {
-    width: 70%;
+    width: 73%;
     margin-bottom: 6px;
   }
 }


### PR DESCRIPTION
examples for operators
formatting tweaks to keep examples on one line
extra space before bracketed info
