### PR TITLE
browser: fix ie9 manual date entry issue

### DIFF
--- a/appserver/java-spring/static/app/directives/ssFacetDateRange.js
+++ b/appserver/java-spring/static/app/directives/ssFacetDateRange.js
@@ -545,6 +545,8 @@ define(['app/module'], function (module) {
             scope.$apply(function () {
               ngModelCtrl.$setViewValue(elm.val());
             });
+            event.preventDefault();
+            event.stopPropagation();
           }
         });
       }

--- a/browser/src/app/directives/ssFacetDateRange.js
+++ b/browser/src/app/directives/ssFacetDateRange.js
@@ -545,6 +545,8 @@ define(['app/module'], function (module) {
             scope.$apply(function () {
               ngModelCtrl.$setViewValue(elm.val());
             });
+            event.preventDefault();
+            event.stopPropagation();
           }
         });
       }


### PR DESCRIPTION
Stops ENTER key event from bubbling up, triggering a page refresh on IE9.  This makes it look your manual entry into the date field disappeared.

Closes #412
