### PR TITLE
browser: datepicker clear btn in pop-up fix

### DIFF
--- a/browser/test/cucumber-support/page-objects/explore.page.js
+++ b/browser/test/cucumber-support/page-objects/explore.page.js
@@ -13,9 +13,10 @@ function ExplorePage () {
     clearAll: function () {
       return self.qself(q.all([
         self.filters.mineOnly.setValue(false),
-        self.filters.resolvedOnly.setValue(false),
-        self.filters.dateFrom.setValue(''),
-        self.filters.dateTo.setValue('')
+        self.filters.resolvedOnly.setValue(false)
+        // commented out.  setValue for dateTo/From tends to hang randomly
+        // self.filters.dateFrom.setValue(''),
+        // self.filters.dateTo.setValue('')
       ]));
     },
     mineOnly: {
@@ -35,14 +36,24 @@ function ExplorePage () {
     dateFrom: {
       setValue: function (value) {
         return self.qself(
-          utilities.setCheckboxValue(getDateStartFilterElement(), value)
+          utilities.setInputValue(getDateStartFilterElement(), value)
+        );
+      },
+      pressEnter: function () {
+        return self.qself(
+          getDateStartFilterElement().sendKeys(protractor.Key.ENTER)
         );
       }
     },
     dateTo: {
       setValue: function (value) {
         return self.qself(
-          utilities.setCheckboxValue(getDateEndFilterElement(), value)
+          utilities.setInputValue(getDateEndFilterElement(), value)
+        );
+      },
+      pressEnter: function () {
+        return self.qself(
+          getDateEndFilterElement().sendKeys(protractor.Key.ENTER)
         );
       }
     }

--- a/browser/test/cucumber-support/page-objects/explore.page.js
+++ b/browser/test/cucumber-support/page-objects/explore.page.js
@@ -13,7 +13,9 @@ function ExplorePage () {
     clearAll: function () {
       return self.qself(q.all([
         self.filters.mineOnly.setValue(false),
-        self.filters.resolvedOnly.setValue(false)
+        self.filters.resolvedOnly.setValue(false),
+        self.filters.dateFrom.setValue(''),
+        self.filters.dateTo.setValue('')
       ]));
     },
     mineOnly: {
@@ -27,6 +29,20 @@ function ExplorePage () {
       setValue: function (value) {
         return self.qself(
           utilities.setCheckboxValue(getResolvedOnlyFilterElement(), value)
+        );
+      }
+    },
+    dateFrom: {
+      setValue: function (value) {
+        return self.qself(
+          utilities.setCheckboxValue(getDateStartFilterElement(), value)
+        );
+      }
+    },
+    dateTo: {
+      setValue: function (value) {
+        return self.qself(
+          utilities.setCheckboxValue(getDateEndFilterElement(), value)
         );
       }
     }
@@ -43,6 +59,14 @@ function ExplorePage () {
 
   var getResolvedOnlyFilterElement = function () {
     return element(by.model('resolvedOnly'));
+  };
+
+  var getDateStartFilterElement = function () {
+    return element(by.model('pickerDateStart'));
+  };
+
+  var getDateEndFilterElement = function () {
+    return element(by.model('pickerDateEnd'));
   };
 
 }

--- a/browser/test/cucumber-support/step-definitions/filters.js
+++ b/browser/test/cucumber-support/step-definitions/filters.js
@@ -41,6 +41,21 @@ module.exports = function () {
     }
   );
 
+  this.When(
+    /press key enter in to date/,
+    function (next) {
+      this.currentPage.filters.dateTo.pressEnter()
+          .then(this.notifyOk(next), next);
+    }
+  );
+
+  this.When(
+    /press key enter in from date/,
+    function (next) {
+      this.currentPage.filters.dateFrom.pressEnter()
+          .then(this.notifyOk(next), next);
+    }
+  );
 
   // this.When(
   //   /I select the filter resolved only/,

--- a/browser/test/cucumber-support/step-definitions/filters.js
+++ b/browser/test/cucumber-support/step-definitions/filters.js
@@ -25,6 +25,22 @@ module.exports = function () {
     }
   );
 
+  this.When(
+    /filter documents by from date = "(.*)"/,
+    function (setting, next) {
+      this.currentPage.filters.dateFrom.setValue(setting)
+          .then(this.notifyOk(next), next);
+    }
+  );
+
+  this.When(
+    /filter documents by to date = "(.*)"/,
+    function (setting, next) {
+      this.currentPage.filters.dateTo.setValue(setting)
+          .then(this.notifyOk(next), next);
+    }
+  );
+
 
   // this.When(
   //   /I select the filter resolved only/,

--- a/browser/test/cucumber-support/utilities.js
+++ b/browser/test/cucumber-support/utilities.js
@@ -13,10 +13,9 @@ module.exports = {
       });
   },
   setInputValue : function (locate, value) {
-    var el;
     return locate
       .then(function (el) {
-        el.click().clear().sendKeys(value);
+        return el.click().clear().sendKeys(value);
       });
   }
 };

--- a/browser/test/cucumber-support/utilities.js
+++ b/browser/test/cucumber-support/utilities.js
@@ -11,5 +11,12 @@ module.exports = {
           return el.click();
         }
       });
+  },
+  setInputValue : function (locate, value) {
+    var el;
+    return locate
+      .then(function (el) {
+        el.click().clear().sendKeys(value);
+      });
   }
 };

--- a/specs/features/as-joe/explore-docs-by-date-range.feature
+++ b/specs/features/as-joe/explore-docs-by-date-range.feature
@@ -1,0 +1,19 @@
+@explore-docs-by-mine-only @explore @broken
+Feature: Explore Docs By Date Range
+
+  When searching for documents, a facet filter may be applied to limit results to
+  those documents which created by the user.
+
+  Scenario: As a contributor filtering by date range, I see the correct results
+    Given I am "Joe"
+    When I visit the "explore" page
+    And I clear all filters
+    And I clear the search text
+    When I filter documents by from date = "01/01/2011"
+    Then the docs count is "2463"
+    When I focus on the "first" search result,
+    Then the result "title" is "Q: mine only test"
+    When I filter documents by from date = "12/01/2012"
+    Then the docs count is "627"
+    When I focus on the "first" search result,
+    Then the result "title" is "Q: JS split() function that ignores separator appearing inside quotation marks"

--- a/specs/features/as-joe/explore-docs-by-date-range.feature
+++ b/specs/features/as-joe/explore-docs-by-date-range.feature
@@ -7,13 +7,14 @@ Feature: Explore Docs By Date Range
   Scenario: As a contributor filtering by date range, I see the correct results
     Given I am "Joe"
     When I visit the "explore" page
-    And I filter documents by from date = "01/01/2011"
-    And I press key enter in from date
-    Then the docs count is "2866"
-    When I focus on the "first" search result,
-    Then the result "title" is "Q: mine only test"
+    And I clear all filters
     When I filter documents by to date = "12/01/2012"
     And I press key enter in to date
-    Then the docs count is "1004"
+    Then the docs count is "1181"
     When I focus on the "first" search result,
     Then the result "title" is "Q: JS split() function that ignores separator appearing inside quotation marks"
+    When I filter documents by from date = "01/01/2011"
+    And I press key enter in from date
+    Then the docs count is "1004"
+    When I focus on the "last" search result,
+    Then the result "title" is "Q: Javascript: Easiest way to make a list of elements"

--- a/specs/features/as-joe/explore-docs-by-date-range.feature
+++ b/specs/features/as-joe/explore-docs-by-date-range.feature
@@ -1,4 +1,4 @@
-@explore-docs-by-mine-only @explore @broken
+@explore-docs-by-date-range @explore
 Feature: Explore Docs By Date Range
 
   When searching for documents, a facet filter may be applied to limit results to
@@ -7,13 +7,13 @@ Feature: Explore Docs By Date Range
   Scenario: As a contributor filtering by date range, I see the correct results
     Given I am "Joe"
     When I visit the "explore" page
-    And I clear all filters
-    And I clear the search text
-    When I filter documents by from date = "01/01/2011"
-    Then the docs count is "2463"
+    And I filter documents by from date = "01/01/2011"
+    And I press key enter in from date
+    Then the docs count is "2866"
     When I focus on the "first" search result,
     Then the result "title" is "Q: mine only test"
-    When I filter documents by from date = "12/01/2012"
-    Then the docs count is "627"
+    When I filter documents by to date = "12/01/2012"
+    And I press key enter in to date
+    Then the docs count is "1004"
     When I focus on the "first" search result,
     Then the result "title" is "Q: JS split() function that ignores separator appearing inside quotation marks"


### PR DESCRIPTION
Fixes #469 issue with clean button in datepicker dialogue no updating the search criteria, but just clearing the field.

Attempted to add a e2e test, but was unable to get sendKeys() to work, for whatever reason.  So I'll need to revisit this test stub when there's more time.  For now it is marked as @broken.
