### PR TITLE
browser: replaced angular-ui tooltips with title attributes tooltips

### DIFF
--- a/browser/src/app/directives/ssAccountDropdown.html
+++ b/browser/src/app/directives/ssAccountDropdown.html
@@ -2,8 +2,7 @@
 <a href="" class="dropdown-toggle"
   dropdown-toggle
   is-open="open"
-  tooltip-placement="bottom"
-  tooltip="View account information or log out"
+  title="View account information or log out"
   >
   <span class="glyphicon glyphicon-user"></span>
   <span class="ss-user-info-display-name-reputation">

--- a/browser/src/app/directives/ssFacetDateRange.js
+++ b/browser/src/app/directives/ssFacetDateRange.js
@@ -54,15 +54,14 @@ define(['app/module'], function (module) {
 
         template:
           '<div ' +
-          ' tooltip="Constrain results to selected dates.' +
+          ' title="Constrain results to selected dates.' +
           ' Drag to select a date range.">' +
           '<highchart class="highcharts ss-facet-date-range" ' +
           '  config="highchartsConfig"></highchart></div>' +
           '<div class="input-daterange input-group">' +
           '<input ng-model="pickerDateStart" type="text" ' +
           '  class="input-sm form-control ng-valid-date" ' +
-          '  tooltip-placement="bottom" ' +
-          '  tooltip=' +
+          '  title=' +
               '"Constrain results to entries beginning on selected date" ' +
           '  datepicker-popup="MM/dd/yyyy" ' +
           '  datepicker-options="dateStartOptions" ' +
@@ -77,8 +76,7 @@ define(['app/module'], function (module) {
 
           '<input ng-model="pickerDateEnd" type="text" ' +
           '  class="input-sm form-control ng-valid-date" ' +
-          '  tooltip-placement="bottom" ' +
-          '  tooltip=' +
+          '  title=' +
               '"Constrain results to entries ending on selected date" ' +
           '  datepicker-popup="MM/dd/yyyy" ' +
           '  datepicker-options="dateEndOptions" ' +

--- a/browser/src/app/directives/ssFacetTags.html
+++ b/browser/src/app/directives/ssFacetTags.html
@@ -22,8 +22,7 @@
           placeholder="Search Tags"
           autocomplete="off"
           ng-model="selected"
-          tooltip-placement="right"
-          tooltip="Search all available tags"
+          title="Search all available tags"
           typeahead="
             tag.count as tag.name+' ('+tag.count+')'
             for tag in typeaheadSearch($viewValue) | filter:$viewValue | orderBy:sort
@@ -47,8 +46,7 @@
       ng-repeat="tag in toArray(selTags) | orderBy:sort"
     >
       <label
-          tooltip-placement="right"
-          tooltip="Constrain results to selected tag"
+          title="Constrain results to selected tag"
       >
         <input
           type="checkbox"
@@ -70,8 +68,7 @@
                  limitTo:tagLimit"
     >
       <label
-          tooltip-placement="right"
-          tooltip="Show tags related to this tag"
+          title="Show tags related to this tag"
       >
         <input
           type="checkbox"
@@ -86,8 +83,7 @@
 
   <!-- more tags button -->
   <button class="button-more-tags btn btn-default btn-block btn-sm"
-    tooltip-placement="right"
-    tooltip="View all available tags"
+    title="View all available tags"
     data-toggle="modal"
     data-target="#tagsModal"
     ng-click="showAllTagsDialog()"

--- a/browser/src/app/directives/ssMarkdownEditor.html
+++ b/browser/src/app/directives/ssMarkdownEditor.html
@@ -37,41 +37,41 @@
       >
         <div class="btn-group-wrapper markdown-controls">
           <div class="btn-group">
-            <wiz-toolbar-button command="bold" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Bold (Strong)" command="bold" class="btn btn-default btn-sm">
               <i class="icon-bold"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="italic" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Italic (Emphasis)" command="italic" class="btn btn-default btn-sm">
               <i class="icon-italic"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="heading" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Heading" command="heading" class="btn btn-default btn-sm">
               <i class="icon-header"></i>
             </wiz-toolbar-button>
           </div>
           <div class="btn-group">
-            <wiz-toolbar-button command="code" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Code Sample" command="code" class="btn btn-default btn-sm">
               <i class="icon-code"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="ollist" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Numbered List" command="ollist" class="btn btn-default btn-sm">
               <i class="icon-ordered"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="ullist" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Bulleted List" command="ullist" class="btn btn-default btn-sm">
               <i class="icon-list"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="link" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Hyperlink" command="link" class="btn btn-default btn-sm">
               <i class="icon-link"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="img" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Image" command="img" class="btn btn-default btn-sm">
               <i class="icon-image"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="hr" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Horizontal Rule" command="hr" class="btn btn-default btn-sm">
               <i class="icon-hr"></i>
             </wiz-toolbar-button>
           </div>
           <div class="btn-group">
-            <wiz-toolbar-button command="undo" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Undo" command="undo" class="btn btn-default btn-sm">
               <i class="icon-undo"></i>
             </wiz-toolbar-button>
-            <wiz-toolbar-button command="redo" class="btn btn-default btn-sm">
+            <wiz-toolbar-button title="Redo" command="redo" class="btn btn-default btn-sm">
               <i class="icon-redo"></i>
             </wiz-toolbar-button>
           </div>

--- a/browser/src/app/directives/ssQnaDocMetadata.html
+++ b/browser/src/app/directives/ssQnaDocMetadata.html
@@ -4,8 +4,7 @@
   <!-- question tags -->
   <div class="ss-question-tags">
       <a href=""
-        tooltip-placement="bottom"
-        tooltip="Perform new search for only this tag"
+        title="Perform new search for this tag"
         ng-click="goTag(tag)"
         ng-repeat="tag in doc.tags">
         <span class="label label-default">{{tag}}</span>
@@ -31,13 +30,13 @@
       <span ng-if="doc.owner && doc.owner.id != 'unknown'" class="ss-author">
         <a
           ng-if="doc.owner.originalId === undefined"
-          tooltip="View this user's account details"
+          title="View this user's account details"
           href=""
           ng-click="showContributor()"
         >{{doc.owner.displayName}}</a>
         <a
           ng-if="!(doc.owner.originalId === undefined)"
-          tooltip="View this user's profile page on Stack Overflow (in a separate window)"
+          title="View this user's profile page on Stack Overflow (in a separate window)"
           href="{{soUserLink()}}"
           target="_blank"
         >{{doc.owner.displayName}}&nbsp;&nbsp;<span class="glyphicon glyphicon-new-window"></span></a>
@@ -45,7 +44,7 @@
         <span
           ng-if="doc.owner.reputation !== undefined"
         >[<span class="ss-reputation"
-          tooltip="Reputation"
+          title="Reputation"
         >{{doc.owner.reputation}}</span>]</span>
       </span>
     </span>
@@ -66,12 +65,12 @@
       <a
         ng-if="doc.owner.originalId === undefined"
         href=""
-        tooltip="View this user's account details"
+        title="View this user's account details"
         ng-click="showContributor()"
       >{{doc.owner.displayName}}</a>
       <a
         ng-if="!(doc.owner.originalId === undefined)"
-        tooltip="View this user's profile page on Stack Overflow (in a separate window)"
+        title="View this user's profile page on Stack Overflow (in a separate window)"
         href="{{soUserLink()}}"
         target="_blank"
       >{{doc.owner.displayName}}&nbsp;&nbsp;<span class="glyphicon glyphicon-new-window"></span>&nbsp;</a>

--- a/browser/src/app/directives/ssSearchBar.html
+++ b/browser/src/app/directives/ssSearchBar.html
@@ -5,8 +5,7 @@
     <button
       type="button"
       class="search-tips btn btn-primary btn-lg"
-      tooltip-placement="bottom"
-      tooltip="View tips for constructing advanced search expressions"
+      title="View tips for constructing advanced search expressions"
       ng-click="showTips=!showTips"
     >
       <i class="icon-pointer-down" ng-if="!showTips"></i>
@@ -39,8 +38,7 @@
         type="search"
         ng-model="searchbarText"
         placeholder="Search the Stack!..."
-        tooltip-placement="bottom"
-        tooltip="Enter search terms and advanced search expressions. (See Search Tips for help.)"
+        title="Enter search terms and advanced search expressions. (See Search Tips for help.)"
         value=""
         ng-keyup="$event.keyCode == 13 && setQueryText()"
       >

--- a/browser/src/app/directives/ssSearchResult.html
+++ b/browser/src/app/directives/ssSearchResult.html
@@ -28,7 +28,7 @@
     <h4>
       <a
         class="ss-result-title"
-        tooltip="View this question and all associated answers"
+        title="View this question and all associated answers"
         ui-sref="root.layout.qnaDoc({ id: item.content.id, q: search.criteria.q })"
         ng-bind-template="Q: {{::item.content.title}}"
       >

--- a/browser/src/app/directives/ssSearchResults.html
+++ b/browser/src/app/directives/ssSearchResults.html
@@ -45,7 +45,7 @@
             href=""
             role="tab"
             data-toggle="tab"
-            tooltip="{{sort.active ? sort.tooltip : (sort.tooltipDisabled || '')}}"
+            title="{{sort.active ? sort.tooltip : (sort.tooltipDisabled || '')}}"
             ng-class="{
               'ss-sort-selected': (
                 sort.value[0] === getSelectedSort()

--- a/browser/src/app/states/_layout.html
+++ b/browser/src/app/states/_layout.html
@@ -22,8 +22,7 @@
           <a class="ss-app-title navbar-brand" href="/">
             <img src="app/images/samplestack.svg"
               border="0"
-              tooltip-placement="bottom"
-              tooltip="Return to home page" >
+              title="Return to home page">
           </a>
 
         </div>
@@ -51,8 +50,7 @@
             <li
               class="ss-ask-button"
               ng-class="store.session ? 'active' : 'inactive'"
-              tooltip-placement="bottom"
-              tooltip="{{store.session ? '': 'You must be logged in to ask a question' }}"
+              title="{{store.session ? '': 'You must be logged in to ask a question' }}"
             >
               <a
                 href=""

--- a/browser/src/app/states/explore.html
+++ b/browser/src/app/states/explore.html
@@ -29,8 +29,7 @@
               <label
                 ng-disabled="!store.session"
                 ng-class="{'ss-disabled': !store.session}"
-                tooltip-placement="right"
-                tooltip="Constrain results to entries containg my contributions"
+                title="Constrain results to entries containing my contributions"
               >
                 <input
                   type="checkbox"
@@ -42,8 +41,7 @@
             <div class="checkbox">
               <label
                 ng-class="{'ss-disabled': !store.session}"
-                tooltip-placement="right"
-                tooltip="Constrain results to entries with accepted answers"
+                title="Constrain results to entries with accepted answers"
                 ng-disabled="!store.session"
               >
                 <!-- resolvedOnly checked when not logged in -->

--- a/browser/src/app/states/qnaDoc.html
+++ b/browser/src/app/states/qnaDoc.html
@@ -14,8 +14,7 @@
       <div class="ss-vote-module">
         <div
           class="ss-vote-control ss-vote-control-up"
-          tooltip-placement="right"
-          tooltip="{{ tooltipUpFor(doc) }}"
+          title="{{ tooltipUpFor(doc) }}"
           ng-click="vote(1, doc)"
           ng-disabled="!canVoteOn(doc)"
         >
@@ -31,8 +30,7 @@
         </div>
         <div
           class="ss-vote-control ss-vote-control-down"
-          tooltip-placement="right"
-          tooltip="{{ tooltipDownFor(doc) }}"
+          title="{{ tooltipDownFor(doc) }}"
           ng-disabled="!canVoteOn(doc)"
           ng-click="vote(-1, doc)"
         >
@@ -56,7 +54,7 @@
             <a
               href="http://stackoverflow.com/questions/{{doc.originalId}}"
               target="_blank"
-              tooltip="View this question on Stack Overflow (in a separate window)"
+              title="View this question on Stack Overflow (in a separate window)"
               ng-if="doc.originalId"
             >
               <span class="glyphicon glyphicon-new-window"></span>
@@ -151,8 +149,7 @@
         <div class="ss-vote-module">
           <div
             class="ss-vote-control ss-vote-control-up"
-            tooltip-placement="right"
-            tooltip="{{ tooltipUpFor(answer) }}"
+            title="{{ tooltipUpFor(answer) }}"
             ng-disabled="!canVoteOn(answer)"
             ng-click="vote(1, answer)"
           >
@@ -168,8 +165,7 @@
           </div>
           <div
             class="ss-vote-control ss-vote-control-down"
-            tooltip-placement="right"
-            tooltip="{{ tooltipDownFor(answer) }}"
+            title="{{ tooltipDownFor(answer) }}"
             ng-disabled="!canVoteOn(answer)"
             ng-click="vote(-1, answer)"
           >
@@ -185,6 +181,7 @@
           <div class="ss-accept text-center" >
             <div
               class="ss-unaccepted"
+              title="Accept this answer"
               ng-if="canAcceptAnswer(answer) &&
                      answer.id != doc.acceptedAnswerId"
               ng-click="accept(answer)"


### PR DESCRIPTION
Due to test failures with angular-ui tooltips, we have removed them in favor of title attributes tooltips (browser built-in style tooltip).
