### PR TITLE
node: get more tags and ask tags working

### DIFF
--- a/appserver/node-express/lib/db-client/tags/hookStartRequest.js
+++ b/appserver/node-express/lib/db-client/tags/hookStartRequest.js
@@ -6,7 +6,7 @@ mlrest.startRequest = function (operation) {
   if (
     operation.options.path === '/v1/search?format=json&category=content' &&
     operation.requestBody && operation.requestBody.search &&
-    operation.requestBody.search.forTag
+    operation.requestBody.search.forTag !== undefined
   ) {
     operation.options.path = '/v1/values/tags?' +
         'pageLength=10000&options=tags&start=1&aggregate=count';

--- a/appserver/node-express/lib/db-client/tags/index.js
+++ b/appserver/node-express/lib/db-client/tags/index.js
@@ -11,9 +11,12 @@ var filterResponse = function (response, forTag, start, pageLength) {
       var newVals = [];
       var ignored = 0;
       _.each(distinct, function (distinctVal) {
+        // Add if empty forTag (no filter) or forTag is in value
         if (!forTag || distinctVal._value.indexOf(forTag) >= 0) {
-          if (zeroIndexStart - 1 <= ignored) {
+          // Adjust for starting index
+          if (zeroIndexStart <= ignored) {
             newVals.push(distinctVal);
+            // Limit reached, exit from _.each
             if (newVals.length === pageLength) {
               return false;
             }
@@ -23,7 +26,6 @@ var filterResponse = function (response, forTag, start, pageLength) {
           }
         }
       });
-
       vals['distinct-value'] = newVals;
     }
   }
@@ -31,19 +33,36 @@ var filterResponse = function (response, forTag, start, pageLength) {
 };
 
 // TODO In 8.0-1, CANNOT include parse* information with Node Client values
-// call, thus we can't get tags constrained to current search qtext/facets
+// call, thus we can't get tags constrained to current search qtext
 // or typeahead text.
 // Fixed in 8.0-2: https://github.com/marklogic/node-client-api/issues/155
-//.DO NOT TRY THE BELOW TECHNIQUE AT HONME.
+//.DO NOT TRY THE BELOW TECHNIQUE AT HOME.
 // The use of the hookStartRequest is not recommended. It is a temporary workaround
 // for Samplestack 1.1.0, to be used only as long as compatibility with Node
 // Client version 1.0.1 is required.
 funcs.getTags = function (spec) {
-  spec.search.qtext.push('tagword:"*' + spec.search.forTag + '*"');
+  // if forTags exists, put into qtext
+  if (spec.search.forTag) {
+    spec.search.qtext.push('tagword:"*' + spec.search.forTag + '*"');
+  }
+  // else, set to empty string (!= undefined)
+  // hookStartRequest checks !== undefined to determine tags call
+  else {
+    spec.search.forTag = '';
+  }
   var start = spec.search.start;
   delete spec.search.start;
   var pageLength = spec.search.pageLength;
   delete spec.search.pageLength;
+
+  // sort order
+  var order = '';
+  if (spec.search.sort === 'frequency') {
+    order = 'frequency-order';
+  }
+  else {
+    order = 'item-order';
+  }
 
   spec.search.options = {
     values: {
@@ -52,7 +71,7 @@ funcs.getTags = function (spec) {
         'json-property': 'tags'
       },
       name: 'tags',
-      'values-option': 'item-order'
+      'values-option': order
     }
   };
   var result = this.documents.query(spec).result();

--- a/appserver/node-express/lib/routing/tags.js
+++ b/appserver/node-express/lib/routing/tags.js
@@ -7,19 +7,19 @@ module.exports = function (app, mw) {
     mw.parseBody.json,
 
     function (req, res, next) {
-      // Handle typeahead and ask tags
-      if (req.body.search.forTag) {
-        return req.db.tags.getTags(req.body)
+      // Handle related tags
+      if (req.body.search.relatedTo) {
+        return req.db.tags.getRelatedTags(req.body)
         .then(function (result) {
+          // TODO make it work
           return res.status(200).send(result);
         })
         .catch(next);
       }
-      // Handle related tags
-      else if (req.body.search.relatedTo) {
-        return req.db.tags.getRelatedTags(req.body)
+      // Handle typeahead, more tags, and ask tags
+      else {
+        return req.db.tags.getTags(req.body)
         .then(function (result) {
-          // TODO make it work
           return res.status(200).send(result);
         })
         .catch(next);


### PR DESCRIPTION
More Tags dialog and Enter Tags on Ask page (along with typeahead for tags) now work (i.e., return same as is seen in Java tier).

More Tags and Enter Tags use the same /v1/tags call as tags typeahead but without a forTag property set. To account for this:
- in routing.js, make the case without a relatedTo property the default case (handles typeahead, more tags, ask tags). This just required a reversal of the if logic.
- If forTag is undefined in db-client code, set it to an empty string since hookStartRequest needs to see forTag set to _something_ to recognize a tags endpoint call. (I suspect there is a less hacky way to do this. We'll also have to make further adjustments in hookStartRequest when we handle related tags -- e.g., check for the presence of forTags _or_ relatedTags properties.)

Fixed an index-related bug in filterResponse().

Added sort order logic.
