### PR TITLE
browser: in tags input on ask page, sort by name

### DIFF
--- a/appserver/java-spring/static/app/states/ask.js
+++ b/appserver/java-spring/static/app/states/ask.js
@@ -34,7 +34,7 @@ define(['app/module'], function (module) {
           tagsQuery: {
             start: 1,
             pageLength: 100,
-            sort: 'frequency',
+            sort: 'name',
             forTag: ' '
           }
         }

--- a/browser/src/app/states/ask.js
+++ b/browser/src/app/states/ask.js
@@ -34,7 +34,7 @@ define(['app/module'], function (module) {
           tagsQuery: {
             start: 1,
             pageLength: 100,
-            sort: 'frequency',
+            sort: 'name',
             forTag: ' '
           }
         }


### PR DESCRIPTION
In the tags input directive, update the ssTagsSearch sort criteria property to sort the tag results by name (alphabetically) not by frequency.

Depends on updates in the following PR for sort by name to work on the node tier (among other things, this PR enables the node tier to recognize tag sorts):
https://github.com/laurelnaiad/marklogic-samplestack/pull/77

Closes #569
