### PR TITLE
browser: in all tags dialog, reset to first page on sort change

### DIFF
--- a/appserver/java-spring/static/app/dialogs/allTags.js
+++ b/appserver/java-spring/static/app/dialogs/allTags.js
@@ -155,6 +155,7 @@ define(['app/module'], function (module) {
        */
       $scope.setSort = function () {
         $scope.selectedSort = this.sort;
+        $scope.currentPage = 1; // reset to first page
         search();
       };
 

--- a/browser/src/app/dialogs/allTags.js
+++ b/browser/src/app/dialogs/allTags.js
@@ -155,6 +155,7 @@ define(['app/module'], function (module) {
        */
       $scope.setSort = function () {
         $scope.selectedSort = this.sort;
+        $scope.currentPage = 1; // reset to first page
         search();
       };
 


### PR DESCRIPTION
When the user selects a new sort in the All Tags dialog, reset the current page in pagination to 1.

Closes #518
