### PR TITLE
node: documentation for code supporting answer, ask, and vote

### DIFF
--- a/appserver/node-express/lib/db-client/contributor/index.js
+++ b/appserver/node-express/lib/db-client/contributor/index.js
@@ -6,11 +6,14 @@ var util = libRequire('db-client/util');
 
 var funcs = {};
 
-/*
- * REPUTATION CHANGE
- * A contributor's reputation may be changed up or down --
- * repChange may be a positive or negative int. Use server-side
- * math so we don't need to read the value into the middle-tier
+/**
+ * Handle an update to a contributor's reputation. This occurs during
+ * a question vote, an answer vote, or an answer acceptance.
+ *
+ * @param  {String} txid The transaction ID.
+ * @param  {String} id The contributor ID.
+ * @param  {Number} repChange Increment or decrement value.
+ * @return {Promise} A promise object.
  */
 funcs.patchReputation = function (txid, id, repChange) {
   // add (or subtract) from reputation property
@@ -19,18 +22,6 @@ funcs.patchReputation = function (txid, id, repChange) {
     uri: meta.getUri(id),
     operations: [
       pb.replace('reputation', pb.add(repChange))
-    ]
-  }).result()
-  .then(meta.responseToSpec);
-};
-
-funcs.patchVoteCount = function (txid, id, voteCountChange) {
-  // add (or subtract) from voteCount property
-  return this.documents.patch({
-    txid: txid,
-    uri: meta.getUri(id),
-    operations: [
-      pb.replace('voteCount', pb.add(voteCountChange))
     ]
   }).result()
   .then(meta.responseToSpec);

--- a/appserver/node-express/lib/db-client/qnaDoc/index.js
+++ b/appserver/node-express/lib/db-client/qnaDoc/index.js
@@ -24,6 +24,17 @@ funcs.search = function (spec) {
   ).result();
 };
 
+/**
+ * Get one or more documents from the Samplestack database based ID(s).
+ * For single documents, apply a transform to include voting and
+ * reputation information.
+ *
+ * @param  {String} txid The transaction ID.
+ * @param  {Object|Array} spec An object with a document ID property. Example:
+ *   {"id":"b6ff5e47-2d08-4c20-9a16-4998fbb1bc10"}
+ * For multiple documents, an array of objects (not currently used).
+ * @return {Promise} A promise object.
+ */
 funcs.getUniqueContent = function (txid, spec) {
   // TODO: this is identical to the code for contributor (except for the pojo
   // issue)... abstract it?
@@ -43,6 +54,27 @@ funcs.getUniqueContent = function (txid, spec) {
   }
 };
 
+/**
+ * Handle the post of a new question to Samplestack. The posted question
+ * is merged with a question template object, a unique ID, contributor
+ * information, and the current time. The resulting object is written to
+ * the MarkLogic database with a URI based on the unique ID.
+ *
+ * @param  {String} txid Transaction ID (currently unused and set to null)
+ * @param  {Object} contributor Contributor objectExample:
+ *   {"id":"cf99542d-f024-4478-a6dc-7e723a51b040",
+ *    "displayName":"JoeUser"}
+ * @param  {Object} spec New question content object. Example:
+ *   {"title":"What is foo?",
+ *    "text":"I want to know about foo.",
+ *    "tags":["foo", "bar"]}
+ * @return {Promise} A promise object. When fulfilled, the response for the
+ * promise includes the new document URI. Example response object:
+ *   {"documents":[{
+ *     "uri":"/questions/5ddb169f-b5d0-4be6-bba5-77277a719b3b.json",
+ *     "contentType":null}
+ *   ]}
+ */
 funcs.post = function (txid, contributor, spec) {
   var id = util.uuid();
   var now = moment();
@@ -57,6 +89,7 @@ funcs.post = function (txid, contributor, spec) {
     }
   );
 
+  // @see http://docs.marklogic.com/jsdoc/documents.html#write
   return this.documents.write({
     txid: txid,
     uri: meta.getUri(newDoc.id),

--- a/appserver/node-express/lib/routing/question.js
+++ b/appserver/node-express/lib/routing/question.js
@@ -150,6 +150,25 @@ module.exports = function (app, mw) {
     }
   ]);
 
+  /**
+   * Check if a contributor has not already voted on a question or answer.
+   * @param  {Object} content Content for the question or answer being
+   * checked.
+   * @param  {Object} contributor Contributor objectExample:
+   *   {"id":"cf99542d-f024-4478-a6dc-7e723a51b040",
+   *    "displayName":"JoeUser"}
+   * @return {[type]}
+   */
+  var notAlreadyVoted = function (content, contributor) {
+    var already = content.upvotingContributorIds.indexOf(contributor.id) >= 0 ||
+    content.downvotingContributorIds.indexOf(contributor.id) >= 0;
+    if (already) {
+      throw errs.alreadyVoted(content, contributor);
+    }
+    else {
+      return;
+    }
+  };
 
   /*
    * Route for the following requests


### PR DESCRIPTION
DOCUMENT the following:

In contributor/index.js:
patchReputation()

In qnaDoc/index.js:
getUniqueContent()
post()

In qnaDoc/patch.js:
votePatch()
patchQuestionVote()
xpathAnswerSelect()
patchAnswerVote()
patchQuestionAddAnswer()

In routing/question.js:
notAlreadyVoted()

Also REMOVE, in contributor/index.js:
patchVoteCount() (Not used. Functionality is handled by votePatch() in patch.js.)
