### PR TITLE
browser: in search tips, capitalize "joeUser" to "JoeUser"

### DIFF
--- a/browser/src/app/directives/ssSearchBar.html
+++ b/browser/src/app/directives/ssSearchBar.html
@@ -85,10 +85,10 @@
         <div class="row">
           <label class="col-xs-6 text-right">user:</label>
           <div class="col-xs-6 sample">
-            <p>user:joeUser&nbsp;&nbsp;&nbsp;[for any submission]</p>
-            <p>askedBy:joeUser</p>
-            <p>answeredBy:joeUser</p>
-            <p>commentedBy:joeUser</p>
+            <p>user:JoeUser&nbsp;&nbsp;&nbsp;[for any submission]</p>
+            <p>askedBy:JoeUser</p>
+            <p>answeredBy:JoeUser</p>
+            <p>commentedBy:JoeUser</p>
           </div>
         </div>
         <div class="row">


### PR DESCRIPTION
closes marklogic/samplestack-internal#121
